### PR TITLE
Fix readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@ Transport Analysis
 ==============================
 [//]: # (Badges)
 
-| **Latest release** | [![Last release tag](https://img.shields.io/github/release-pre/MDAnalysis/transport_analysis.svg)](https://github.com/MDAnalysis/transport_analysis/releases) ![GitHub commits since latest release (by date) for a branch](https://img.shields.io/github/commits-since/MDAnalysis/transport_analysis/latest)  [![Documentation Status](https://readthedocs.org/projects/transport_analysis/badge/?version=latest)](https://transport_analysis.readthedocs.io/en/latest/?badge=latest)|
+| **Latest release** | [![Last release tag](https://img.shields.io/github/release-pre/MDAnalysis/transport-analysis.svg)](https://github.com/MDAnalysis/transport-analysis/releases) ![GitHub commits since latest release (by date) for a branch](https://img.shields.io/github/commits-since/MDAnalysis/transport-analysis/latest)  [![Documentation Status](https://readthedocs.org/projects/transport-analysis/badge/?version=latest)](https://transport-analysis.readthedocs.io/en/latest/?badge=latest)|
 | :------ | :------- |
-| **Status** | [![GH Actions Status](https://github.com/MDAnalysis/transport_analysis/actions/workflows/gh-ci.yaml/badge.svg)](https://github.com/MDAnalysis/transport_analysis/actions?query=branch%3Amain+workflow%3Agh-ci) [![codecov](https://codecov.io/gh/MDAnalysis/transport_analysis/branch/main/graph/badge.svg)](https://codecov.io/gh/MDAnalysis/transport_analysis/branch/main) |
+| **Status** | [![GH Actions Status](https://github.com/MDAnalysis/transport-analysis/actions/workflows/gh-ci.yaml/badge.svg)](https://github.com/MDAnalysis/transport-analysis/actions?query=branch%3Amain+workflow%3Agh-ci) [![codecov](https://codecov.io/gh/MDAnalysis/transport-analysis/branch/main/graph/badge.svg)](https://codecov.io/gh/MDAnalysis/transport-analysis/branch/main) |
 | **Community** | [![License: GPL v2](https://img.shields.io/badge/License-GPLv2-blue.svg)](https://www.gnu.org/licenses/gpl-2.0)  [![Powered by MDAnalysis](https://img.shields.io/badge/powered%20by-MDAnalysis-orange.svg?logoWidth=16&logo=data:image/x-icon;base64,AAABAAEAEBAAAAEAIAAoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJD+XwCY/fEAkf3uAJf97wGT/a+HfHaoiIWE7n9/f+6Hh4fvgICAjwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACT/yYAlP//AJ///wCg//8JjvOchXly1oaGhv+Ghob/j4+P/39/f3IAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJH8aQCY/8wAkv2kfY+elJ6al/yVlZX7iIiI8H9/f7h/f38UAAAAAAAAAAAAAAAAAAAAAAAAAAB/f38egYF/noqAebF8gYaagnx3oFpUUtZpaWr/WFhY8zo6OmT///8BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgICAn46Ojv+Hh4b/jouJ/4iGhfcAAADnAAAA/wAAAP8AAADIAAAAAwCj/zIAnf2VAJD/PAAAAAAAAAAAAAAAAICAgNGHh4f/gICA/4SEhP+Xl5f/AwMD/wAAAP8AAAD/AAAA/wAAAB8Aov9/ALr//wCS/Z0AAAAAAAAAAAAAAACBgYGOjo6O/4mJif+Pj4//iYmJ/wAAAOAAAAD+AAAA/wAAAP8AAABhAP7+FgCi/38Axf4fAAAAAAAAAAAAAAAAiIiID4GBgYKCgoKogoB+fYSEgZhgYGDZXl5e/m9vb/9ISEjpEBAQxw8AAFQAAAAAAAAANQAAADcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAjo6Mb5iYmP+cnJz/jY2N95CQkO4pKSn/AAAA7gAAAP0AAAD7AAAAhgAAAAEAAAAAAAAAAACL/gsAkv2uAJX/QQAAAAB9fX3egoKC/4CAgP+NjY3/c3Nz+wAAAP8AAAD/AAAA/wAAAPUAAAAcAAAAAAAAAAAAnP4NAJL9rgCR/0YAAAAAfX19w4ODg/98fHz/i4uL/4qKivwAAAD/AAAA/wAAAP8AAAD1AAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALGxsVyqqqr/mpqa/6mpqf9KSUn/AAAA5QAAAPkAAAD5AAAAhQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADkUFBSuZ2dn/3V1df8uLi7bAAAATgBGfyQAAAA2AAAAMwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB0AAADoAAAA/wAAAP8AAAD/AAAAWgC3/2AAnv3eAJ/+dgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA9AAAA/wAAAP8AAAD/AAAA/wAKDzEAnP3WAKn//wCS/OgAf/8MAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAANwAAADtAAAA7QAAAMAAABUMAJn9gwCe/e0Aj/2LAP//AQAAAAAAAAAA)](https://www.mdanalysis.org)|
 
 A Python package to compute and analyze transport properties.
 
-Transport Analysis is bound by a [Code of Conduct](https://github.com/MDAnalysis/transport_analysis/blob/main/CODE_OF_CONDUCT.md).
+Transport Analysis is bound by a [Code of Conduct](https://github.com/MDAnalysis/transport-analysis/blob/main/CODE_OF_CONDUCT.md).
 
 ### Installation
 
@@ -73,8 +73,8 @@ pip install -e ".[test,doc]"
 
 ### Copyright
 
-The Transport Analysis source code is hosted at https://github.com/MDAnalysis/transport_analysis
-and is available under the GNU General Public License, version 2 (see the file [LICENSE](https://github.com/MDAnalysis/transport_analysis/blob/main/LICENSE)).
+The Transport Analysis source code is hosted at https://github.com/MDAnalysis/transport-analysis
+and is available under the GNU General Public License, version 2 (see the file [LICENSE](https://github.com/MDAnalysis/transport-analysis/blob/main/LICENSE)).
 
 Copyright (c) 2023, Xu Hong Chen
 


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

This should make all the badges in the readme work now (things were pointing to transport_analysis instead of transport-analysis).

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
