### PR TITLE
Make `tidynamics` a core dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
     # do not use for Conda deployment
     install_requires=[
         "mdanalysis>=2.0.0",
+        "tidynamics>=1.0.0",
     ],
     # Additional entries you may want simply uncomment the lines you want and fill in the data
     # url='transport_analysis.readthedocs.io/en/latest/',  # Website

--- a/transport_analysis/analysis/velocityautocorr.py
+++ b/transport_analysis/analysis/velocityautocorr.py
@@ -11,6 +11,7 @@ from MDAnalysis.analysis.base import AnalysisBase
 from MDAnalysis.core.groups import UpdatingAtomGroup
 from MDAnalysis.exceptions import NoDataError
 import numpy as np
+import tidynamics
 from transport_analysis.analysis.due import due, Doi
 
 if TYPE_CHECKING:
@@ -162,21 +163,6 @@ class VelocityAutocorr(AnalysisBase):
 
     def _conclude_fft(self):  # with FFT, np.float64 bit prescision required.
         r"""Calculates the VACF via the FCA fast correlation algorithm."""
-        try:
-            import tidynamics
-        except ImportError:
-            raise ImportError(
-                """ERROR --- tidynamics was not found!
-
-                tidynamics is required to compute an FFT based VACF (default)
-
-                try installing it using pip eg:
-
-                    pip install tidynamics
-
-                or set fft=False"""
-            )
-
         velocities = self._velocity_array.astype(np.float64)
         for n in range(self.n_particles):
             self.results.vacf_by_particle[:, n] = tidynamics.acf(

--- a/transport_analysis/tests/analysis/test_velocityautocorr.py
+++ b/transport_analysis/tests/analysis/test_velocityautocorr.py
@@ -6,7 +6,7 @@ from transport_analysis.analysis.velocityautocorr import (
 )
 import MDAnalysis as mda
 import numpy as np
-from tidynamics import acf
+import tidynamics
 
 from MDAnalysis.exceptions import NoDataError
 from MDAnalysisTests.datafiles import PRM_NCBOX, TRJ_NCBOX
@@ -89,7 +89,7 @@ def test_characteristic_poly(step_vtraj, NSTEP, tdim, tdim_keys):
         step_velocities[i] = step_vtraj.atoms.velocities[:, tdim_keys]
 
     for n in range(n_particles):
-        expected[:, n] = acf(step_velocities[:, n, :])
+        expected[:, n] = tidynamics.acf(step_velocities[:, n, :])
 
     # average over n_particles
     expected = expected.mean(axis=1)

--- a/transport_analysis/tests/analysis/test_velocityautocorr.py
+++ b/transport_analysis/tests/analysis/test_velocityautocorr.py
@@ -6,10 +6,10 @@ from transport_analysis.analysis.velocityautocorr import (
 )
 import MDAnalysis as mda
 import numpy as np
+from tidynamics import acf
 
 from MDAnalysis.exceptions import NoDataError
 from MDAnalysisTests.datafiles import PRM_NCBOX, TRJ_NCBOX
-from MDAnalysisTests.util import block_import, import_not_available
 
 
 @pytest.fixture(scope="module")
@@ -71,48 +71,34 @@ def characteristic_poly(last, n_dim, first=0, step=1):
     return result
 
 
-@block_import("tidynamics")
-def test_notidynamics(ag):
-    with pytest.raises(ImportError, match="tidynamics was not found"):
-        vacf = VACF(ag)
-        vacf.run()
-
-
 @pytest.mark.parametrize(
     "tdim, tdim_keys", [(1, [0]), (2, [0, 1]), (3, [0, 1, 2])]
 )
 def test_characteristic_poly(step_vtraj, NSTEP, tdim, tdim_keys):
     # test `characteristic_poly()` against `tidynamics.acf()``
-    try:
-        from tidynamics import acf
-    except ImportError:
-        pytest.skip(
-            "Skipping the test for characteristic_poly() "
-            "because the import failed"
-        )
-    else:
-        # expected result from tidynamics.acf()
-        # n_particles should be 1 unless modifying the test
-        n_particles = len(step_vtraj.atoms)
-        # 2D array of frames x particles
-        expected = np.zeros((NSTEP, n_particles))
-        # 3D array of frames x particles x dimensions
-        step_velocities = np.zeros((NSTEP, n_particles, tdim))
 
-        for i, ts in enumerate(step_vtraj.trajectory):
-            step_velocities[i] = step_vtraj.atoms.velocities[:, tdim_keys]
+    # expected result from tidynamics.acf()
+    # n_particles should be 1 unless modifying the test
+    n_particles = len(step_vtraj.atoms)
+    # 2D array of frames x particles
+    expected = np.zeros((NSTEP, n_particles))
+    # 3D array of frames x particles x dimensions
+    step_velocities = np.zeros((NSTEP, n_particles, tdim))
 
-        for n in range(n_particles):
-            expected[:, n] = acf(step_velocities[:, n, :])
+    for i, ts in enumerate(step_vtraj.trajectory):
+        step_velocities[i] = step_vtraj.atoms.velocities[:, tdim_keys]
 
-        # average over n_particles
-        expected = expected.mean(axis=1)
+    for n in range(n_particles):
+        expected[:, n] = acf(step_velocities[:, n, :])
 
-        # result from characteristic_poly()
-        actual = characteristic_poly(NSTEP, tdim)
+    # average over n_particles
+    expected = expected.mean(axis=1)
 
-        # compare actual and expected
-        assert_almost_equal(actual, expected, decimal=4)
+    # result from characteristic_poly()
+    actual = characteristic_poly(NSTEP, tdim)
+
+    # compare actual and expected
+    assert_almost_equal(actual, expected, decimal=4)
 
 
 class TestVelocityAutocorr:
@@ -196,10 +182,6 @@ class TestVelocityAutocorr:
         assert_almost_equal(v_simple.results.timeseries, poly, decimal=4)
 
 
-@pytest.mark.skipif(
-    import_not_available("tidynamics"),
-    reason="Test skipped because tidynamics not found",
-)
 class TestVACFFFT(object):
     @pytest.fixture(scope="class")
     def vacf_fft(self, ag):


### PR DESCRIPTION
Resolves #14 

Changes made in this Pull Request:
 - Add `tidynamics` to `install_requires=` in `setup.py`
 - Remove the "tidynamics was not found" import warning
 - Remove the skip if no `tidynamics` parts in the tests
 - Update `tidynamics` import for consistency