### PR TITLE
Create plotting function for VACF

### DIFF
--- a/transport_analysis/tests/test_velocityautocorr.py
+++ b/transport_analysis/tests/test_velocityautocorr.py
@@ -284,3 +284,16 @@ def test_plot_vacf_labels(vacf):
 
     assert x_act == x_exp
     assert y_act == y_exp
+
+
+def test_plot_vacf_start_stop_step(vacf, start=1, stop=9, step=2):
+    # Expected data to be plotted
+    x_exp = vacf.times[start:stop:step]
+    y_exp = vacf.results.timeseries[start:stop:step]
+
+    # Actual data returned from plot
+    (line,) = plot_vacf(vacf, start=start, stop=stop, step=step)
+    x_act, y_act = line.get_xydata().T
+
+    assert_allclose(x_act, x_exp)
+    assert_allclose(y_act, y_exp)

--- a/transport_analysis/tests/test_velocityautocorr.py
+++ b/transport_analysis/tests/test_velocityautocorr.py
@@ -3,7 +3,6 @@ from numpy.testing import assert_almost_equal, assert_allclose
 
 from transport_analysis.velocityautocorr import (
     VelocityAutocorr as VACF,
-    plot_vacf,
 )
 import MDAnalysis as mda
 import numpy as np
@@ -182,6 +181,43 @@ class TestVelocityAutocorr:
         # polynomial must take offset start into account
         assert_almost_equal(v_simple.results.timeseries, poly, decimal=4)
 
+    def test_plot_vacf(self, vacf):
+        # Expected data to be plotted
+        x_exp = vacf.times
+        y_exp = vacf.results.timeseries
+
+        # Actual data returned from plot
+        (line,) = vacf.plot_vacf()
+        x_act, y_act = line.get_xydata().T
+
+        assert_allclose(x_act, x_exp)
+        assert_allclose(y_act, y_exp)
+
+    def test_plot_vacf_labels(self, vacf):
+        # Expected labels
+        x_exp = "Time (ps)"
+        y_exp = "Velocity Autocorrelation Function (VACF) (Å)"
+
+        # Actual labels returned from plot
+        (line,) = vacf.plot_vacf()
+        x_act = line.axes.get_xlabel()
+        y_act = line.axes.get_ylabel()
+
+        assert x_act == x_exp
+        assert y_act == y_exp
+
+    def test_plot_vacf_start_stop_step(self, vacf, start=1, stop=9, step=2):
+        # Expected data to be plotted
+        x_exp = vacf.times[start:stop:step]
+        y_exp = vacf.results.timeseries[start:stop:step]
+
+        # Actual data returned from plot
+        (line,) = vacf.plot_vacf(start=start, stop=stop, step=step)
+        x_act, y_act = line.get_xydata().T
+
+        assert_allclose(x_act, x_exp)
+        assert_allclose(y_act, y_exp)
+
 
 class TestVACFFFT(object):
     @pytest.fixture(scope="class")
@@ -257,43 +293,3 @@ class TestVACFFFT(object):
         )
         # polynomial must take offset start into account
         assert_almost_equal(v_simple.results.timeseries, poly, decimal=3)
-
-
-def test_plot_vacf(vacf):
-    # Expected data to be plotted
-    x_exp = vacf.times
-    y_exp = vacf.results.timeseries
-
-    # Actual data returned from plot
-    (line,) = plot_vacf(vacf)
-    x_act, y_act = line.get_xydata().T
-
-    assert_allclose(x_act, x_exp)
-    assert_allclose(y_act, y_exp)
-
-
-def test_plot_vacf_labels(vacf):
-    # Expected labels
-    x_exp = "Time (ps)"
-    y_exp = "Velocity Autocorrelation Function (VACF) (Å)"
-
-    # Actual labels returned from plot
-    (line,) = plot_vacf(vacf)
-    x_act = line.axes.get_xlabel()
-    y_act = line.axes.get_ylabel()
-
-    assert x_act == x_exp
-    assert y_act == y_exp
-
-
-def test_plot_vacf_start_stop_step(vacf, start=1, stop=9, step=2):
-    # Expected data to be plotted
-    x_exp = vacf.times[start:stop:step]
-    y_exp = vacf.results.timeseries[start:stop:step]
-
-    # Actual data returned from plot
-    (line,) = plot_vacf(vacf, start=start, stop=stop, step=step)
-    x_act, y_act = line.get_xydata().T
-
-    assert_allclose(x_act, x_exp)
-    assert_allclose(y_act, y_exp)

--- a/transport_analysis/tests/test_velocityautocorr.py
+++ b/transport_analysis/tests/test_velocityautocorr.py
@@ -265,7 +265,7 @@ def test_plot_vacf(vacf):
     y_exp = vacf.results.timeseries
 
     # Actual data returned from plot
-    line, = plot_vacf(vacf)
+    (line,) = plot_vacf(vacf)
     x_act, y_act = line.get_xydata().T
 
     assert_allclose(x_act, x_exp)
@@ -278,7 +278,7 @@ def test_plot_vacf_labels(vacf):
     y_exp = "Velocity Autocorrelation Function (VACF) (Å)"
 
     # Actual labels returned from plot
-    line, = plot_vacf(vacf)
+    (line,) = plot_vacf(vacf)
     x_act = line.axes.get_xlabel()
     y_act = line.axes.get_ylabel()
 

--- a/transport_analysis/tests/test_velocityautocorr.py
+++ b/transport_analysis/tests/test_velocityautocorr.py
@@ -1,8 +1,9 @@
 import pytest
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_allclose
 
 from transport_analysis.velocityautocorr import (
     VelocityAutocorr as VACF,
+    plot_vacf,
 )
 import MDAnalysis as mda
 import numpy as np
@@ -256,3 +257,30 @@ class TestVACFFFT(object):
         )
         # polynomial must take offset start into account
         assert_almost_equal(v_simple.results.timeseries, poly, decimal=3)
+
+
+def test_plot_vacf(vacf):
+    # Expected data to be plotted
+    x_exp = vacf.times
+    y_exp = vacf.results.timeseries
+
+    # Actual data returned from plot
+    line, = plot_vacf(vacf)
+    x_act, y_act = line.get_xydata().T
+
+    assert_allclose(x_act, x_exp)
+    assert_allclose(y_act, y_exp)
+
+
+def test_plot_vacf_labels(vacf):
+    # Expected labels
+    x_exp = "Time (ps)"
+    y_exp = "Velocity Autocorrelation Function (VACF) (Å)"
+
+    # Actual labels returned from plot
+    line, = plot_vacf(vacf)
+    x_act = line.axes.get_xlabel()
+    y_act = line.axes.get_ylabel()
+
+    assert x_act == x_exp
+    assert y_act == y_exp

--- a/transport_analysis/velocityautocorr.py
+++ b/transport_analysis/velocityautocorr.py
@@ -234,8 +234,10 @@ class VelocityAutocorr(AnalysisBase):
 def plot_vacf(vacf_obj, start=0, stop=0, step=1):
     stop = vacf_obj.n_frames if stop == 0 else stop
 
-    plt.xlabel('Time (ps)')
-    plt.ylabel('Velocity Autocorrelation Function (VACF) (Å)')
-    plt.title('Velocity Autocorrelation Function vs. Time')
-    plt.plot(vacf_obj.times[start:stop:step],
-             vacf_obj.results.timeseries[start:stop:step])
+    plt.xlabel("Time (ps)")
+    plt.ylabel("Velocity Autocorrelation Function (VACF) (Å)")
+    plt.title("Velocity Autocorrelation Function vs. Time")
+    plt.plot(
+        vacf_obj.times[start:stop:step],
+        vacf_obj.results.timeseries[start:stop:step],
+    )

--- a/transport_analysis/velocityautocorr.py
+++ b/transport_analysis/velocityautocorr.py
@@ -49,7 +49,7 @@ from MDAnalysis.core.groups import UpdatingAtomGroup
 from MDAnalysis.exceptions import NoDataError
 import numpy as np
 import tidynamics
-from matplotlib import pyplot as plt
+import matplotlib.pyplot as plt
 from transport_analysis.due import due, Doi
 
 if TYPE_CHECKING:
@@ -234,10 +234,10 @@ class VelocityAutocorr(AnalysisBase):
 def plot_vacf(vacf_obj, start=0, stop=0, step=1):
     stop = vacf_obj.n_frames if stop == 0 else stop
 
-    plt.xlabel("Time (ps)")
-    plt.ylabel("Velocity Autocorrelation Function (VACF) (Å)")
-    plt.title("Velocity Autocorrelation Function vs. Time")
-    plt.plot(
+    fig, ax_vacf = plt.subplots()
+    ax_vacf.set_xlabel("Time (ps)")
+    ax_vacf.set_ylabel("Velocity Autocorrelation Function (VACF) (Å)")
+    return ax_vacf.plot(
         vacf_obj.times[start:stop:step],
         vacf_obj.results.timeseries[start:stop:step],
     )

--- a/transport_analysis/velocityautocorr.py
+++ b/transport_analysis/velocityautocorr.py
@@ -58,7 +58,7 @@ if TYPE_CHECKING:
 due.cite(
     Doi("10.21105/joss.00877"),
     description="Autocorrelation with tidynamics",
-    path="transport_analysis.analysis.velocityautocorr",
+    path="transport_analysis.velocityautocorr",
     cite_module=True,
 )
 

--- a/transport_analysis/velocityautocorr.py
+++ b/transport_analysis/velocityautocorr.py
@@ -94,7 +94,7 @@ class VelocityAutocorr(AnalysisBase):
     start : Optional[int]
         The first frame of the trajectory used to compute the analysis.
     stop : Optional[int]
-        The frame to stop at for the analysis.
+        The frame to stop at for the analysis, non-inclusive.
     step : Optional[int]
         Number of frames to skip between each analyzed frame.
     n_frames : int
@@ -232,6 +232,32 @@ class VelocityAutocorr(AnalysisBase):
 
 
 def plot_vacf(vacf_obj, start=0, stop=0, step=1):
+    """
+    Returns a velocity autocorrelation function (VACF) plot via
+    ``Matplotlib``.
+
+    Parameters
+    ----------
+    vacf_obj : :class:`~transport_analysis.velocityautocorr.VelocityAutocorr`
+        A transport analysis
+        :class:`~transport_analysis.velocityautocorr.VelocityAutocorr`.
+        Must be run prior to plotting.
+    start : Optional[int]
+        The first frame of ``vacf_obj.results.timeseries``
+        used for the plot.
+    stop : Optional[int]
+        The frame of ``vacf_obj.results.timeseries`` to stop at
+        for the plot, non-inclusive.
+    step : Optional[int]
+        Number of frames to skip between each plotted frame.
+
+    Returns
+    -------
+    :class:`matplotlib.lines.Line2D`
+        A :class:`matplotlib.lines.Line2D` instance with
+        the desired VACF plotting information.
+    """
+
     stop = vacf_obj.n_frames if stop == 0 else stop
 
     fig, ax_vacf = plt.subplots()

--- a/transport_analysis/velocityautocorr.py
+++ b/transport_analysis/velocityautocorr.py
@@ -230,40 +230,35 @@ class VelocityAutocorr(AnalysisBase):
         # average over # particles and update results array
         self.results.timeseries = self.results.vacf_by_particle.mean(axis=1)
 
+    def plot_vacf(self, start=0, stop=0, step=1):
+        """
+        Returns a velocity autocorrelation function (VACF) plot via
+        ``Matplotlib``. Analysis must be run prior to plotting.
 
-def plot_vacf(vacf_obj, start=0, stop=0, step=1):
-    """
-    Returns a velocity autocorrelation function (VACF) plot via
-    ``Matplotlib``.
+        Parameters
+        ----------
+        start : Optional[int]
+            The first frame of ``self.results.timeseries``
+            used for the plot.
+        stop : Optional[int]
+            The frame of ``self.results.timeseries`` to stop at
+            for the plot, non-inclusive.
+        step : Optional[int]
+            Number of frames to skip between each plotted frame.
 
-    Parameters
-    ----------
-    vacf_obj : :class:`~transport_analysis.velocityautocorr.VelocityAutocorr`
-        A transport analysis
-        :class:`~transport_analysis.velocityautocorr.VelocityAutocorr`.
-        Must be run prior to plotting.
-    start : Optional[int]
-        The first frame of ``vacf_obj.results.timeseries``
-        used for the plot.
-    stop : Optional[int]
-        The frame of ``vacf_obj.results.timeseries`` to stop at
-        for the plot, non-inclusive.
-    step : Optional[int]
-        Number of frames to skip between each plotted frame.
+        Returns
+        -------
+        :class:`matplotlib.lines.Line2D`
+            A :class:`matplotlib.lines.Line2D` instance with
+            the desired VACF plotting information.
+        """
 
-    Returns
-    -------
-    :class:`matplotlib.lines.Line2D`
-        A :class:`matplotlib.lines.Line2D` instance with
-        the desired VACF plotting information.
-    """
+        stop = self.n_frames if stop == 0 else stop
 
-    stop = vacf_obj.n_frames if stop == 0 else stop
-
-    fig, ax_vacf = plt.subplots()
-    ax_vacf.set_xlabel("Time (ps)")
-    ax_vacf.set_ylabel("Velocity Autocorrelation Function (VACF) (Å)")
-    return ax_vacf.plot(
-        vacf_obj.times[start:stop:step],
-        vacf_obj.results.timeseries[start:stop:step],
-    )
+        fig, ax_vacf = plt.subplots()
+        ax_vacf.set_xlabel("Time (ps)")
+        ax_vacf.set_ylabel("Velocity Autocorrelation Function (VACF) (Å)")
+        return ax_vacf.plot(
+            self.times[start:stop:step],
+            self.results.timeseries[start:stop:step],
+        )

--- a/transport_analysis/velocityautocorr.py
+++ b/transport_analysis/velocityautocorr.py
@@ -49,6 +49,7 @@ from MDAnalysis.core.groups import UpdatingAtomGroup
 from MDAnalysis.exceptions import NoDataError
 import numpy as np
 import tidynamics
+from matplotlib import pyplot as plt
 from transport_analysis.due import due, Doi
 
 if TYPE_CHECKING:
@@ -228,3 +229,13 @@ class VelocityAutocorr(AnalysisBase):
             self.results.vacf_by_particle[lag, :] = np.mean(sum_veloc, axis=0)
         # average over # particles and update results array
         self.results.timeseries = self.results.vacf_by_particle.mean(axis=1)
+
+
+def plot_vacf(vacf_obj, start=0, stop=0, step=1):
+    stop = vacf_obj.n_frames if stop == 0 else stop
+
+    plt.xlabel('Time (ps)')
+    plt.ylabel('Velocity Autocorrelation Function (VACF) (Å)')
+    plt.title('Velocity Autocorrelation Function vs. Time')
+    plt.plot(vacf_obj.times[start:stop:step],
+             vacf_obj.results.timeseries[start:stop:step])


### PR DESCRIPTION
Towards #7 

Changes made in this Pull Request:
 - Add `plot_vacf()` to easily plot VACFs via `Matplotlib`
 - Add tests to validate plot data, plot labels, and start, stop, step functionality