### PR TITLE
Correct units for self-diffusivity

### DIFF
--- a/transport_analysis/tests/test_velocityautocorr.py
+++ b/transport_analysis/tests/test_velocityautocorr.py
@@ -226,7 +226,7 @@ class TestVelocityAutocorr:
     def test_plot_running_integral_labels(self, vacf):
         # Expected labels
         x_exp = "Time (ps)"
-        y_exp = "Running Integral of the VACF (Å^dimensionality / ps)"
+        y_exp = "Running Integral of the VACF (Å^2 / ps)"
 
         # Actual labels returned from plot
         (line,) = vacf.plot_running_integral()

--- a/transport_analysis/velocityautocorr.py
+++ b/transport_analysis/velocityautocorr.py
@@ -386,7 +386,7 @@ class VelocityAutocorr(AnalysisBase):
         fig, ax_running_integral = plt.subplots()
         ax_running_integral.set_xlabel("Time (ps)")
         ax_running_integral.set_ylabel(
-            "Running Integral of the VACF (Å^dimensionality / ps)"
+            "Running Integral of the VACF (Å^2 / ps)"
         )
         return ax_running_integral.plot(
             self.times[start:stop:step],


### PR DESCRIPTION
Fixes #30 

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - Correct units from Å^D/ps to Å^2/ps
